### PR TITLE
Add Smart Audience Engine plugin

### DIFF
--- a/smart-audience-engine/readme.txt
+++ b/smart-audience-engine/readme.txt
@@ -1,0 +1,10 @@
+=== Smart Audience Engine ===
+Contributors: your-agency-name
+Tags: gtm, google tag manager, tracking
+Requires at least: 4.6
+Tested up to: 6.0
+Stable tag: 1.0.0
+License: MIT
+License URI: https://opensource.org/licenses/MIT
+
+A zero-configuration plugin that injects your Google Tag Manager container into every page.

--- a/smart-audience-engine/smart-audience-engine.php
+++ b/smart-audience-engine/smart-audience-engine.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Plugin Name: Smart Audience Engine
+ * Description: Automatically adds your GTM container to every page. Zero setup required.
+ * Version:     1.0.0
+ * Author:      Your Agency Name
+ * Text Domain: smart-audience-engine
+ */
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Set the GTM container ID via constant or filter.
+ * Define `SAE_GTM_ID` in `wp-config.php` or use the `sae_gtm_id` filter to override.
+ * When printing the ID, always escape it (e.g., with `esc_attr()`).
+ */
+if ( ! defined( 'SAE_GTM_ID' ) ) {
+    define( 'SAE_GTM_ID', 'GTM-P6LVXLBZ' );
+}
+
+add_action( 'wp_head', 'sae_insert_gtm_head', 1 );
+function sae_insert_gtm_head() {
+    $gtm_id = esc_attr( apply_filters( 'sae_gtm_id', SAE_GTM_ID ) );
+    ?>
+    <!-- Google Tag Manager -->
+    <script>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<?php echo $gtm_id; ?>');
+    </script>
+    <!-- End Google Tag Manager -->
+    <?php
+}
+
+if ( function_exists( 'wp_body_open' ) ) {
+    add_action( 'wp_body_open', 'sae_insert_gtm_body', 1 );
+} else {
+    add_action( 'wp_footer', 'sae_insert_gtm_body', 0 ); // Fallback for older themes
+}
+function sae_insert_gtm_body() {
+    ?>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=<?php echo esc_attr( apply_filters( 'sae_gtm_id', SAE_GTM_ID ) ); ?>"
+              height="0" width="0" style="display:none;visibility:hidden">
+      </iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <?php
+}


### PR DESCRIPTION
## Summary
- implement WordPress plugin per coding instructions
- plugin injects GTM code into head/body
- add simple readme

## Testing
- `ls -R | head -n 20`

------
https://chatgpt.com/codex/tasks/task_b_6851b0b1542c8330ad4c9cb203f74974